### PR TITLE
랭킹 페이지 API 추가

### DIFF
--- a/account/models.py
+++ b/account/models.py
@@ -227,3 +227,7 @@ class UserSolved(models.Model):
 
     class Meta:
         db_table = "user_solved"
+
+    @property
+    def total_solved(self):
+        return self.math_solved + self.implementation_solved + self.datastructure_solved + self.search_solved + self.sorting_solved

--- a/account/serializers.py
+++ b/account/serializers.py
@@ -158,6 +158,15 @@ class SurgeUserSerializer(serializers.ModelSerializer):
     def get_growth(self, obj):
         return obj.userscore.fluctuation
 
+class MajorRankListSerializer(serializers.ModelSerializer):
+    rank = serializers.IntegerField()
+    major = serializers.CharField()
+    score = serializers.IntegerField()
+    people = serializers.IntegerField()
+
+    class Meta:
+        model = Department
+        fields = ['rank', 'major', 'score', 'people']
 
 class DashboardUserInfoSerializer(serializers.ModelSerializer):
     class Meta:

--- a/account/serializers.py
+++ b/account/serializers.py
@@ -103,6 +103,33 @@ class UserProfileSerializer(serializers.ModelSerializer):
     def get_real_name(self, obj):
         return obj.real_name if self.show_real_name else None
 
+class UserRankListSerializer(serializers.ModelSerializer):
+    rank = serializers.SerializerMethodField()
+    avatar = serializers.SerializerMethodField()
+    username = serializers.CharField()  # 수정
+    mood = serializers.CharField(source='userprofile.mood')  # 수정
+    score = serializers.IntegerField(source='userscore.total_score')  # 수정
+    major = serializers.CharField(source='userprofile.major')  # 수정
+    tier = serializers.CharField(source='userscore.tier')  # 수정
+    solved = serializers.SerializerMethodField()
+    growth = serializers.SerializerMethodField()
+
+    class Meta:
+        model = User
+        fields = ['rank', 'avatar', 'username', 'mood', 'score', 'major', 'tier', 'solved', 'growth']
+
+    def get_rank(self, obj):
+        return self.context['rank']
+
+    def get_avatar(self, obj):
+        return obj.userprofile.avatar
+
+    def get_growth(self, obj):
+        return obj.userscore.fluctuation
+
+    def get_solved(self, obj):  # 추가
+        return obj.usersolved.total_solved
+
 
 class DashboardUserInfoSerializer(serializers.ModelSerializer):
     class Meta:

--- a/account/serializers.py
+++ b/account/serializers.py
@@ -131,6 +131,34 @@ class UserRankListSerializer(serializers.ModelSerializer):
         return obj.usersolved.total_solved
 
 
+class SurgeUserSerializer(serializers.ModelSerializer):
+    rank = serializers.SerializerMethodField()
+    avatar = serializers.SerializerMethodField()
+    username = serializers.CharField()
+    mood = serializers.CharField(source='userprofile.mood')
+    score = serializers.IntegerField(source='userscore.total_score')
+    major = serializers.CharField(source='userprofile.major')
+    tier = serializers.CharField(source='userscore.tier')
+    solved = serializers.SerializerMethodField()
+    growth = serializers.SerializerMethodField()
+
+    class Meta:
+        model = User
+        fields = ['rank', 'avatar', 'username', 'mood', 'score', 'major', 'tier', 'solved', 'growth']
+
+    def get_rank(self, obj):
+        return self.context['rank']
+
+    def get_avatar(self, obj):
+        return obj.userprofile.avatar
+
+    def get_solved(self, obj):
+        return obj.usersolved.total_solved
+
+    def get_growth(self, obj):
+        return obj.userscore.fluctuation
+
+
 class DashboardUserInfoSerializer(serializers.ModelSerializer):
     class Meta:
         model = User

--- a/account/urls/oj.py
+++ b/account/urls/oj.py
@@ -8,7 +8,7 @@ from ..views.oj import (ApplyResetPasswordAPI, ResetPasswordAPI, GetRankingAPI,
                         UserRankAPI, CheckTFARequiredAPI, SessionManagementAPI,
                         ProfileProblemDisplayIDRefreshAPI, OpenAPIAppkeyAPI, SSOAPI,
                         ApplyUserEmailValidCheckAPI, UserEmailValidCheckAPI,
-                        GetCollegeListAPI, GetDepartmentListAPI, HomeRankingAPI)
+                        GetCollegeListAPI, GetDepartmentListAPI, HomeRankingAPI, SurgeUserRankAPI)
 
 from utils.captcha.views import CaptchaAPIView
 
@@ -36,6 +36,7 @@ urlpatterns = [
     url(r"^tfa_required/?$", CheckTFARequiredAPI.as_view(), name="tfa_required_check"),
     url(r"^two_factor_auth/?$", TwoFactorAuthAPI.as_view(), name="two_factor_auth_api"),
     url(r"^user_rank/?$", UserRankAPI.as_view(), name="user_rank_api"),
+    url(r"^surge_user_rank/?$", SurgeUserRankAPI.as_view(), name="surge_user_rank_api"),
     url(r"^sessions/?$", SessionManagementAPI.as_view(), name="session_management_api"),
     url(r"^open_api_appkey/?$", OpenAPIAppkeyAPI.as_view(), name="open_api_appkey_api"),
     url(r"^sso?$", SSOAPI.as_view(), name="sso_api")

--- a/account/urls/oj.py
+++ b/account/urls/oj.py
@@ -8,7 +8,7 @@ from ..views.oj import (ApplyResetPasswordAPI, ResetPasswordAPI, GetRankingAPI,
                         UserRankAPI, CheckTFARequiredAPI, SessionManagementAPI,
                         ProfileProblemDisplayIDRefreshAPI, OpenAPIAppkeyAPI, SSOAPI,
                         ApplyUserEmailValidCheckAPI, UserEmailValidCheckAPI,
-                        GetCollegeListAPI, GetDepartmentListAPI, HomeRankingAPI, SurgeUserRankAPI)
+                        GetCollegeListAPI, GetDepartmentListAPI, HomeRankingAPI, SurgeUserRankAPI, MajorRankAPI)
 
 from utils.captcha.views import CaptchaAPIView
 
@@ -37,6 +37,7 @@ urlpatterns = [
     url(r"^two_factor_auth/?$", TwoFactorAuthAPI.as_view(), name="two_factor_auth_api"),
     url(r"^user_rank/?$", UserRankAPI.as_view(), name="user_rank_api"),
     url(r"^surge_user_rank/?$", SurgeUserRankAPI.as_view(), name="surge_user_rank_api"),
+    url(r"^major_rank/?$", MajorRankAPI.as_view(), name="major_rank_api"),
     url(r"^sessions/?$", SessionManagementAPI.as_view(), name="session_management_api"),
     url(r"^open_api_appkey/?$", OpenAPIAppkeyAPI.as_view(), name="open_api_appkey_api"),
     url(r"^sso?$", SSOAPI.as_view(), name="sso_api")

--- a/account/views/oj.py
+++ b/account/views/oj.py
@@ -566,6 +566,27 @@ class UserRankAPI(APIView):
 
         return self.success(data)
 
+class SurgeUserRankAPI(APIView):
+    def get(self, request):
+        offset = int(request.GET.get("offset", 0))
+        limit = int(request.GET.get("limit", 10))
+
+        users = User.objects.prefetch_related('userprofile', 'userscore', 'usersolved') \
+                            .order_by('-userscore__fluctuation')[offset:offset+limit]
+
+        total_users = User.objects.count()
+
+        results = []
+        for rank, user in enumerate(users, start=offset+1):
+            serializer = SurgeUserSerializer(user, context={'rank': rank})
+            results.append(serializer.data)
+
+        data = {
+            'total': total_users,
+            'results': results
+        }
+
+        return self.success(data)
 
 class ProfileProblemDisplayIDRefreshAPI(APIView):
     @login_required

--- a/oj/wsgi.py
+++ b/oj/wsgi.py
@@ -15,6 +15,6 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "oj.settings")
 
 application = get_wsgi_application()
 
-# from utils.scheduler import Scheduler
-# scheduler = Scheduler()
-# scheduler.start()
+from utils.scheduler import Scheduler
+scheduler = Scheduler()
+scheduler.start()


### PR DESCRIPTION
## 주요 변경 사항

- 일반 사용자의 랭킹 API를 추가하였습니다.
  - 기존 API의 /acm-rank/user-rank 프론트 라우터를 /user-rank로 바꿔야할 것으로 보입니다.
- 오늘의 급상승 사용자 랭킹 API를 추가하였습니다.
- 학과별 랭킹 API를 추가하였습니다.
  - 요청하신 학과 랭킹에 기여한 학생들의 정보도 같이 반환합니다. 
  
- 회원가입 시, UserProfile 모델의 School, Major 필드가 null로 되어있던 문제를 해결하였습니다.