### PR TITLE
학과 랭킹 API 오류 수정

### DIFF
--- a/account/views/oj.py
+++ b/account/views/oj.py
@@ -602,7 +602,7 @@ class MajorRankAPI(APIView):
         results = []
         for rank, major in enumerate(major_ranks, start=1):
             people_data = major.userprofile_set.select_related('user', 'user__userscore').annotate(
-                avatar_url=Concat(Value('/public/avatar/'), 'avatar', output_field=TextField()),
+                avatar_url=F('user__userprofile__avatar'),
                 username=F('user__username'),
                 score=F('user__userscore__total_score'),
                 tier=F('user__userscore__tier')


### PR DESCRIPTION
- 학과 랭킹 API 응답의 avatar_url에 /public/avatar/ 디렉토리 경로가 중복되는 문제 해결