### PR TITLE
chore: CSRF 미들웨어를 운영환경에서만 사용하도록 변경

### DIFF
--- a/backend/oj/settings.py
+++ b/backend/oj/settings.py
@@ -63,7 +63,6 @@ INSTALLED_APPS = VENDOR_APPS + LOCAL_APPS
 MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'account.middleware.APITokenAuthMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
@@ -73,6 +72,10 @@ MIDDLEWARE = (
     'account.middleware.SessionRecordMiddleware',
     # 'account.middleware.LogSqlMiddleware',
 )
+
+if production_env:
+    MIDDLEWARE = MIDDLEWARE + ('django.middleware.csrf.CsrfViewMiddleware',)
+
 ROOT_URLCONF = 'oj.urls'
 
 TEMPLATES = [


### PR DESCRIPTION
- 개발의 편리함을 위해 개발환경에서 CSRF를 허용합니다.