### PR TITLE
#166 refactor 어드민 배너 관리 api 수정

### DIFF
--- a/backend/banner/views/admin.py
+++ b/backend/banner/views/admin.py
@@ -199,7 +199,7 @@ class EditAdminBannerAPIView(APIView):
                 logger.exception(e)
                 return self.error("something went wrong")
 
-        return self.success(BannerAdminSerializer(target_banner).data)
+        return self.success(BannerAdminSerializer(Banner.objects.all(), many=True).data)
 
 
 class ReOrderAdminBannerAPIView(APIView):

--- a/backend/banner/views/admin.py
+++ b/backend/banner/views/admin.py
@@ -222,6 +222,9 @@ class ReOrderAdminBannerAPIView(APIView):
         reorder_list = list(request.data.get('reorder_list', None))
         curr_order_list = list(banners_with_order.values_list('id', flat=True).order_by('order'))
 
+        if sorted(reorder_list) != sorted(curr_order_list):
+            return self.error("Invalid order")
+
         result = self.find_first_difference(curr_order_list, reorder_list)
         if result is None:
             return self.success("no difference")

--- a/backend/banner/views/admin.py
+++ b/backend/banner/views/admin.py
@@ -235,6 +235,6 @@ class ReOrderAdminBannerAPIView(APIView):
             Banner.reorder_swap(target_banner, reorder_num)
         except Exception as e:
             logger.exception(e)
-            return self.error(BannerAdminSerializer(banners, many=True).data)
+            return self.error("reorder failed")
 
         return self.success("reorder succeed")


### PR DESCRIPTION
주요 변경 사항
---
- 배너 순서 재조정 API가 실패 시, 에러 메시지만 반환하도록 수정
- 배너 순서 재조정 API에 유효하지 않는 요청에 대한 예외처리
- 배너 활성/비활성화 성공 시, 업데이트된 모든 배너데이터를 반환하도록 수정